### PR TITLE
doc(v-theme-provider): slot must include one root element

### DIFF
--- a/packages/api-generator/src/locale/en/v-theme-provider.json
+++ b/packages/api-generator/src/locale/en/v-theme-provider.json
@@ -1,5 +1,8 @@
 {
   "props": {
     "root": "Use the current value of `$vuetify.theme.dark` as opposed to the provided one."
-  }
+  },
+  "slots": {
+    "default": "All child components will have their theme overrided. Must have exactly one root element."
+  },
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

I specified on the documentation that the `<v-theme-provider>` slot must have only one root element to avoid confusion. Not sure the wording is perfect but at least it mentions the limitation I encountered.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I recently noted that using `<v-theme-provider>` with more than one root element in the slot doesn't work. All elements expect the first one are omitted.

This was not documented at all. And I didn't expected it to happen since Vue `<slot>` doesn't have this limitation. Only components template have it (just to mention it wasn't intuitive to discover this by myself)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
